### PR TITLE
Resource file per task

### DIFF
--- a/app/elements/coder/challenge/page/challenge-page.html
+++ b/app/elements/coder/challenge/page/challenge-page.html
@@ -32,7 +32,7 @@
 			font-weight: 400;
 		}
 
-		.challengeDisplayModal {
+		.modalPadding {
 			padding: 20px 50px 0 50px
 		}
 
@@ -65,8 +65,17 @@
 		</div>
 
 		<paper-dialog id="challengeOverviewModal" modal>
-			<div class="challengeDisplayModal">
+			<div class="modalPadding">
 				<challenge-display challenge="{{challengeTemplate}}"></challenge-display>
+				<div class="paperButtonModal">
+					<paper-button dialog-confirm autofocus>Close</paper-button>
+				</div>
+			</div>
+		</paper-dialog>
+
+		<paper-dialog id="taskInstructionsModal" modal>
+			<div class="modalPadding">
+				<task-display task="{{task}}"></task-display>
 				<div class="paperButtonModal">
 					<paper-button dialog-confirm autofocus>Close</paper-button>
 				</div>
@@ -100,10 +109,14 @@
 				remainingTimeStyle:{
 					type: String,
 					value: 'display: none;'
+				},
+				task: {
+					type: Object
 				}
 			},
 			listeners: {
-				'show-challenge-instructions' : 'showChallengeInstructions'
+				'show-challenge-instructions' : 'showChallengeInstructions',
+				'show-task-instructions' : 'showTaskInstructions'
 			},
 			observers: [
 				'afterPropertiesSet(canonicalName)'
@@ -141,6 +154,10 @@
 			},
 			showChallengeInstructions: function() {
 				this.$.challengeOverviewModal.open();
+			},
+			showTaskInstructions: function(e) {
+				this.task = e.detail;
+				this.$.taskInstructionsModal.open();
 			},
 			replaceContent: function(){
 				var webInterface = document.createElement(this.challengeTemplate.endpoint.component);

--- a/app/elements/coder/challenge/tasks/task-display.html
+++ b/app/elements/coder/challenge/tasks/task-display.html
@@ -10,10 +10,15 @@
 			overflow-y: auto;
 			height: 100%;
 		}
+
+		h1 {
+			margin-bottom: 60px;
+			font-size: 32px;
+		}
 	</style>
 	<template>
 		<div>
-			<h2>{{task.name}}</h2>
+			<h1>{{task.name}}</h1>
 			<render-markdown markdown="{{task.description}}"></render-markdown>
 			<render-markdown markdown="{{task.instructions}}"></render-markdown>
 		</div>

--- a/app/elements/coder/code-editor/code-editor-with-actions.html
+++ b/app/elements/coder/code-editor/code-editor-with-actions.html
@@ -147,7 +147,7 @@
 				'template-fetched': 'handleTemplateFetched'
 			},
 			_goToInstructions: function(){
-				window.open(this.task.instructions, '', '_blank');
+				this.fire('show-task-instructions', this.task);
 			},
 			_download: function(){
 				this.fire('show-challenge-instructions');


### PR DESCRIPTION
In addition to a PDF file that explains the task, it is now possible that tasks
have their own additional resource files. Therefore, a click on the 'instructionsFab'
does not directly trigger the PDF-download but opens a 'task-display'-modal,
 which contains a link to both PDF and resource file (if any).
